### PR TITLE
Faster CI with build caching

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -1,4 +1,4 @@
-name: Compile Blueprint
+name: Compile Blueprinta
 
 on:
   push:
@@ -19,13 +19,6 @@ permissions:
   id-token: write # Write access to ID tokens
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-
-
-jobs:
   build_project:
     runs-on: ubuntu-latest
     name: Build project
@@ -36,6 +29,22 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches and tags
 
       - uses: leanprover/lean-action@v1
+
+      - name: Cache mathlib API docs
+        uses: actions/cache@v4
+        with:
+          path: |
+            .lake/build/doc/Init
+            .lake/build/doc/Lake
+            .lake/build/doc/Lean
+            .lake/build/doc/Std
+            .lake/build/doc/Mathlib
+            .lake/build/doc/declarations
+            .lake/build/doc/find
+            .lake/build/doc/*.*
+            !.lake/build/doc/declarations/declaration-data-BrunnMinkowski*
+          key: MathlibDoc-${{ hashFiles('lake-manifest.json') }}
+          restore-keys: MathlibDoc-${{ hashFiles('lake-manifest.json') }}
 
       - name: Build project API documentation
         run: lake -R -Kenv=dev build BrunnMinkowski:docs

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -1,10 +1,11 @@
-name: Compile Blueprinta
+name: Compile Blueprint
 
 on:
   push:
-    branches: ["main"] # replace "main" with the default branch
+    branches:
+      - main
   pull_request:
-    branches: ["main"]
+    types: [opened, reopened]
   workflow_dispatch:
 
 # Cancel previous runs if a new commit is pushed to the same PR or branch
@@ -39,6 +40,10 @@ jobs:
             .lake/build/doc/Lean
             .lake/build/doc/Std
             .lake/build/doc/Mathlib
+            .lake/build/doc/Batteries
+            .lake/build/doc/Aesop
+            .lake/build/doc/LeanSearchClient
+            .lake/build/doc/ImportGraph
             .lake/build/doc/declarations
             .lake/build/doc/find
             .lake/build/doc/*.*

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -1,12 +1,11 @@
-name: Compile blueprint
+name: Compile Blueprint
 
 on:
   push:
-    branches:
-      - main # Trigger on pushes to the default branch
+    branches: ["main"] # replace "main" with the default branch
   pull_request:
-    types: [opened, reopened]
-  workflow_dispatch:        # Allow manual triggering of the workflow from the GitHub Actions interface
+    branches: ["main"]
+  workflow_dispatch:
 
 # Cancel previous runs if a new commit is pushed to the same PR or branch
 concurrency:
@@ -20,6 +19,13 @@ permissions:
   id-token: write # Write access to ID tokens
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+
+jobs:
   build_project:
     runs-on: ubuntu-latest
     name: Build project
@@ -29,33 +35,10 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
 
-      - name: Install elan
-        run: curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
-
-      - name: Get Mathlib cache
-        run: ~/.elan/bin/lake exe cache get || true
-
-      - name: Build project
-        run: ~/.elan/bin/lake build BrunnMinkowski
-
-      - name: Cache mathlib API docs
-        uses: actions/cache@v4
-        with:
-          path: |
-            .lake/build/doc/Init
-            .lake/build/doc/Lake
-            .lake/build/doc/Lean
-            .lake/build/doc/Std
-            .lake/build/doc/Mathlib
-            .lake/build/doc/declarations
-            .lake/build/doc/find
-            .lake/build/doc/*.*
-            !.lake/build/doc/declarations/declaration-data-BrunnMinkowski*
-          key: MathlibDoc-${{ hashFiles('lake-manifest.json') }}
-          restore-keys: MathlibDoc-
+      - uses: leanprover/lean-action@v1
 
       - name: Build project API documentation
-        run: ~/.elan/bin/lake -R -Kenv=dev build BrunnMinkowski:docs
+        run: lake -R -Kenv=dev build BrunnMinkowski:docs
 
       - name: Check for `home_page` folder # this is meant to detect a Jekyll-based website
         id: check_home_page
@@ -91,7 +74,7 @@ jobs:
 
       - name: Check declarations mentioned in the blueprint exist in Lean code
         run: |
-            ~/.elan/bin/lake exe checkdecls blueprint/lean_decls
+            lake exe checkdecls blueprint/lean_decls
 
       - name: Copy API documentation to `home_page/docs`
         run: cp -r .lake/build/doc home_page/docs

--- a/blueprint/src/print.tex
+++ b/blueprint/src/print.tex
@@ -16,6 +16,8 @@
 
 \usepackage{expl3}
 
+\usepackage{xcolor}
+
 \usepackage{amssymb, amsthm, mathtools}
 \usepackage[unicode,colorlinks=true,linkcolor=blue,urlcolor=magenta, citecolor=blue]{hyperref}
 

--- a/blueprint/src/web.tex
+++ b/blueprint/src/web.tex
@@ -6,6 +6,7 @@
 
 \documentclass{report}
 
+\usepackage{xcolor}
 \usepackage{amssymb, amsthm, amsmath}
 \usepackage{hyperref}
 \usepackage[showmore, dep_graph]{blueprint}


### PR DESCRIPTION
CI previously took ~20 minutes, this PR make CI finish in around 5 minutes by using more caches.

Initial CI run does take full 20 minutes as there is no cache to be used